### PR TITLE
Fixed the regexp to match proper floating point numbers

### DIFF
--- a/lib/pixrem.js
+++ b/lib/pixrem.js
@@ -9,7 +9,7 @@
 // }
 module.exports = function pixrem(css, rootvalue, options) {
   var postcss = require('postcss');
-  var remgex = /(\d+(\.\d+)?)rem/i;
+  var remgex = /(\d*\.?\d+)rem/i;
   var rootvalue = typeof rootvalue !== 'undefined' ? rootvalue : 16;
   var options = typeof options !== 'undefined' ? options : {
     replace: false
@@ -47,7 +47,7 @@ module.exports = function pixrem(css, rootvalue, options) {
 
   // Return a unitless pixel value from any root font-size value.
   function toPx(value) {
-    var parts = /^(\d+\.?\d*)([a-zA-Z%]*)$/.exec(value);
+    var parts = /^(\d*\.?\d+)([a-zA-Z%]*)$/.exec(value);
     var number = parts[1];
     var unit = parts[2];
 


### PR DESCRIPTION
You should use `(\d*\.\d+)` to match numbers, or you'll get `0.5rem` with `10px` rootvalue converted to `0.50px` :)
