### PR TITLE
Update PostCSS and clean code

### DIFF
--- a/lib/pixrem.js
+++ b/lib/pixrem.js
@@ -9,7 +9,7 @@
 // }
 module.exports = function pixrem(css, rootvalue, options) {
   var postcss = require('postcss');
-  var remgex = /(\d*\.?\d+)rem/i;
+  var remgex = /(\d*\.?\d+)rem/ig;
   var rootvalue = typeof rootvalue !== 'undefined' ? rootvalue : 16;
   var options = typeof options !== 'undefined' ? options : {
     replace: false
@@ -18,28 +18,20 @@ module.exports = function pixrem(css, rootvalue, options) {
 
     css.eachDecl(function (decl, i) {
       var rule = decl.parent;
-      var prop = decl.prop;
-      var value = decl._value.trimmed;
+      var value = decl.value;
 
-      if (value.match(remgex)) {
+      if (value.indexOf('rem') != -1) {
 
-        while (value.match(remgex)) {
-          // TODO: Is there an easy way to pull anon function outside of the
-          // loop for perf?
-          value = value.replace(remgex, function ($1) {
-            // Round decimal pixels down to match webkit and opera behavior:
-            // http://tylertate.com/blog/2012/01/05/subpixel-rounding.html
-            return Math.floor(parseFloat($1) * toPx(rootvalue)) + 'px';
-          });
-        }
-
-        rule.insertBefore(i, {
-          prop: prop,
-          value: value
+        value = value.replace(remgex, function ($1) {
+          // Round decimal pixels down to match webkit and opera behavior:
+          // http://tylertate.com/blog/2012/01/05/subpixel-rounding.html
+          return Math.floor(parseFloat($1) * toPx(rootvalue)) + 'px';
         });
 
         if (options.replace) {
-          decl.remove(i);
+          decl.value = value;
+        } else {
+          rule.insertBefore(i, decl.clone({ value: value }));
         }
       }
     });
@@ -65,5 +57,5 @@ module.exports = function pixrem(css, rootvalue, options) {
     return false;
   }
 
-  return postprocessor.process(css);
+  return postprocessor.process(css).css;
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "postcss": "~0.1.0"
+    "postcss": "~0.3.0"
   },
   "devDependencies": {
     "jasmine-node": "~1.11.0"


### PR DESCRIPTION
PostCSS 0.3 was released few days ago with source map support. With old 0.1 your Grunt plugin will broke Sass or Sublime maps.

Also I clean code:
- In Autoprefixer I find, that better to use quick search by `indexOf` and only them use slow RegExps.
- In PostCSS better to clone node rather that create new one. If you clone node, it will take origin code style (like space or not space after colon) and source map will show, that clone was created from origin declaration.
- `decl._value.trimmed` is a internal property, to take trimmed value you can use `value` getter.
