### PR TITLE
fix repository url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "pixrem",
   "description": "A CSS post-processor that generates pixel fallbacks for rem units.",
   "version": "0.1.4",
-  "homepage": "https://github.com/robwierzbowski/pixrem",
+  "homepage": "https://github.com/robwierzbowski/node-pixrem",
   "author": "Rob Wierzbowski <hello@robwierzbowski.com> (http://robwierzbowski.com)",
   "repository": {
     "type": "git",
-    "url": "git://github.com/robwierzbowski/pixrem.git"
+    "url": "git://github.com/robwierzbowski/node-pixrem.git"
   },
-  "bugs": "https://github.com/robwierzbowski/pixrem/issues",
+  "bugs": "https://github.com/robwierzbowski/node-pixrem/issues",
   "licenses": [
     {
       "type": "BSD-new"


### PR DESCRIPTION
Hi there,

Recently found your package on NPM repository but your package.json URLs were obsolete.
Simple fix, really.
