### PR TITLE
Fix default root size through font shorthand

### DIFF
--- a/lib/pixrem.js
+++ b/lib/pixrem.js
@@ -35,7 +35,7 @@ Pixrem.prototype.postcss = function (css) {
       rule.eachDecl(function(decl) {
         if (decl.prop === 'font-size') {
           _rootvalue = decl.value;
-        } else if (decl.prop === 'font') {
+        } else if (decl.prop === 'font' && decl.value.match(/\d/)) {
           _rootvalue = decl.value.match(/.*?([\d\.]*(em|px|rem|%|pt|pc))/)[1];
         }
       });

--- a/spec/pixrem-spec.js
+++ b/spec/pixrem-spec.js
@@ -133,4 +133,12 @@ describe('pixrem', function () {
 
   });
 
+  it('should run through font shorthand without root size', function () {
+    var css = 'html { font: inherit } .rule { font-size: 2rem; }';
+    var expected = 'html { font: inherit } .rule { font-size: 32px; font-size: 2rem; }';
+    var processed = pixrem.process(css);
+
+    expect(processed).toBe(expected);
+  });
+
 });


### PR DESCRIPTION
Hi, 

CSS resets, as example Eric Meyer's one, uses the following rule:

``` css
html {
  ...
  font: inherit;
  ...
}
```

The current version of pixrem nicely try to get predefined root font-size but throw the following error:

``` js
Cannot read property '1' of null
```

I made a quick fix and also added a new spec to ensure coverage for cases like this.

Cheers!
