### PR TITLE
Fixed: prevent node exception if parent does not exist or is undefined

### DIFF
--- a/lib/pixrem.js
+++ b/lib/pixrem.js
@@ -31,7 +31,7 @@ Pixrem.prototype.postcss = function (css) {
 
   // First, check root font-size
   css.eachRule(function (rule) {
-    if (rule.parent.type === 'atrule') { return };
+    if (rule.parent && rule.parent.type === 'atrule') { return };
     if (/(html|:root)/.test(rule.selectors)) {
       rule.eachDecl(function (decl) {
         if (decl.prop === 'font-size') {


### PR DESCRIPTION
Postcss api should not bring an undefined parent for an attached node. However some manual manipulations might create this state and boom, pixrem blow up because a low level test have not been done before.
You should always double check that an object exist before calling a prop on it, since `undefined` me be there... Thats why I do not provide any test. Tests will be added to the responsible for this state. 

Ref https://github.com/cssnext/cssnext/issues/67