### PR TITLE
Update reduce-css-calc dependency to ^1.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "browserslist": "^1.0.0",
     "postcss": "^5.0.0",
-    "reduce-css-calc": "^1.2.0"
+    "reduce-css-calc": "^1.2.7"
   },
   "devDependencies": {
     "mocha": "^2.3.2"


### PR DESCRIPTION
On user setups, `reduce-css-calc` dependency should be upgraded to 1.2.7 or later asap, this ensures that on upgrading `pixrem`, `reduce-css-calc` would be also upgraded.

See https://github.com/MoOx/reduce-css-calc/blob/master/CHANGELOG.md for details.