### PR TITLE
Fix for incorrect processing of 'rem' in base 64 string

### DIFF
--- a/lib/pixrem.js
+++ b/lib/pixrem.js
@@ -4,6 +4,7 @@ var postcss      = require('postcss');
 var browserslist = require('browserslist');
 
 var REGEX = /(\d*\.?\d+)rem/ig;
+var REGEX_FOR_VALUE = /\drem( |\)|$)/i;
 var BASE_FONT_SIZE = 16;
 var PROPS = /^(background-size|border-image|border-radius|box-shadow|clip-path|column|grid|mask|object|perspective|scroll|shape|size|stroke|transform)/;
 var VALUES = /(calc|gradient)\(/;
@@ -67,7 +68,7 @@ module.exports = postcss.plugin('pixrem', function (opts) {
 
         var value = decl.value;
 
-        if (value.indexOf('rem') !== -1) {
+        if (REGEX_FOR_VALUE.test(value)) {
 
           var prop = vendor.unprefixed(decl.prop);
           var isFontShorthand = (prop === 'font');

--- a/test/test.js
+++ b/test/test.js
@@ -282,4 +282,11 @@ describe('pixrem', function () {
     assert.equal(processed, expected);
   });
 
+  it('should not convert rem or duplicate rule for \'rem\' string in base64 data', function () {
+    var css = '.rule{background-image: url(data:image/png;base64,Waj8JihBKremJFeiD0T4wd3rem/vS+lPDE1O3z9eREMu2T);}';
+    var expected = '.rule{background-image: url(data:image/png;base64,Waj8JihBKremJFeiD0T4wd3rem/vS+lPDE1O3z9eREMu2T);}';
+    var processed = postcss([pixrem]).process(css).css;
+    assert.equal(processed, expected);
+  });
+
 });


### PR DESCRIPTION
If a base 64 string has the string 'rem' in it, that rule will be processed (assuming other factors such as browserlist allow it) and duplicated. This fix uses a regex to check the property value rather than a simple indexOf(). The regex checks for a value that has a digit followed by 'rem' followed by a space, or a ), or the end of line. The space character and ) are not valid in base 64 and the ) can be used in calc() functions so it is allowed to process. There is still a small chance that a base64 string could end in a string similar to '3rem' and get processed.

It may be wise to never process `background-image` type properties or values inside of quote marks (even though they aren't required in the url() css function). Or don't process the url() function. This is a quicker, simpler fix and I leave a more holistic solution to those with deeper knowledge of this plugin.