### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - stable
+  - "10"
+  - "8"
   - "6"
-  - "4"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "main": "lib/pixrem.js",
   "engines": {
-    "node": ">=0.10.0",
+    "node": ">=4.0.0",
     "npm": ">=1.2.10"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "test": "mocha"
   },
   "dependencies": {
-    "browserslist": "^2.0.0",
-    "postcss": "^6.0.0",
-    "reduce-css-calc": "^1.2.7"
+    "browserslist": "^4.3.6",
+    "postcss": "^7.0.7",
+    "reduce-css-calc": "^2.1.5"
   },
   "devDependencies": {
     "mocha": "^2.3.2"


### PR DESCRIPTION
@robwierzbowski thanks for your amazing work for this plugin.

I updated dependencies. The most important update is Browserslist. Old Browserslist is slow (@kgrz [found](https://twitter.com/kgrz/status/1078605455188910080) performance impact from `node-pixrem`) and could throw an error on new queries (like very useful `not dead).

PostCSS and `reduce-css-calc` are less important but it will be good to update them.

What version should be used to release it:

1. Browserslist 2.0 → 4.0 will not change public API for this plugin. So you do not need a major bump for it.
2. PostCSS 6.0 → 7.0 does not require any plugin changes. PostCSS 7.0’s plugin will be still compatible with PostCSS 6.0. So you do not need a major bump for it.
3. `reduce-css-calc` 1.0 → 2.0 [changes](https://github.com/MoOx/reduce-css-calc/blob/master/CHANGELOG.md). I didn’t find critical changes.

<s>As result, I think minor changes will be OK (especially, because it will fix Browserslist error on new queries).</s>